### PR TITLE
Pass original classes through styleWith

### DIFF
--- a/src/components/Box/index.js
+++ b/src/components/Box/index.js
@@ -14,10 +14,7 @@ function Box(props) {
   return (
     <ConfigConsumer>
       {({ styleWith = () => "" }) => {
-        remainingProps.className = `${styleWith(
-          className,
-          !!important
-        )} ${className}`.trim()
+        remainingProps.className = `${styleWith(className, !!important)}`.trim()
 
         return React.createElement(is, remainingProps, children)
       }}

--- a/src/createUtilitiesFromConfig.js
+++ b/src/createUtilitiesFromConfig.js
@@ -36,6 +36,10 @@ function getActiveUtilities(classList, utilities, apply) {
     )
 }
 
+function getPassThroughClassNames(classList, utilities) {
+  return classList.split(" ").filter((name) => !utilities[name])
+}
+
 function createUtilityMap(allUtilities = [], theme) {
   return allUtilities
     .map((utilityFn) => utilityFn(theme))
@@ -81,6 +85,11 @@ export default function createUtilitiesFromConfig(configFn = (cfg) => cfg) {
       apply
     )
 
+    const passThroughClasses = getPassThroughClassNames(
+      classNames,
+      utilityClasses
+    )
+
     const activeUtilityRules = activeUtilities.map((name) =>
       parseDeclarations(utilityClasses[name], isImportant).join("")
     )
@@ -96,7 +105,9 @@ export default function createUtilitiesFromConfig(configFn = (cfg) => cfg) {
         `
     )
 
-    return `${defaultResetClass} ${activeUtilityClasses.join(" ")}`
+    return `${defaultResetClass} ${activeUtilityClasses.join(
+      " "
+    )} ${passThroughClasses.join(" ")}`
   }
 
   return {


### PR DESCRIPTION
If a user passes any class that is not recognized by `benefit` to the `styleWith` method, we should just pass them through in the return.

Currently, if you pass a class of `foo` to `styleWith`, it will not be output and get lost in translation.

Code Sandbox example:
> https://codesandbox.io/s/l47zk721jq