### PR TITLE
Add `prefix` option to configuration

### DIFF
--- a/docs/components/Grid.js
+++ b/docs/components/Grid.js
@@ -6,13 +6,12 @@ export default function Grid({ children, className, minWidth = "1fr" }) {
     <Box
       style={{
         display: "grid",
-        marginBottom: "2rem",
         gridTemplateColumns: `repeat(auto-fill, minmax(${minWidth}, 1fr))`,
         gridGap: "1rem",
       }}
       className={className}
     >
-      <>{children}</>
+      {children}
     </Box>
   )
 }

--- a/docs/components/Output.js
+++ b/docs/components/Output.js
@@ -1,0 +1,113 @@
+/** @jsx jsx */
+import { useEffect } from "react"
+import { Code } from "docz"
+import { css } from "emotion"
+import { jsx } from "../../dist/react"
+import benefit from "../../dist/benefit"
+import { formatDeclaration } from "../../src/createUtilitiesFromConfig"
+import Grid from "./Grid"
+import Icon from "./Icons"
+import BrowserBox from "./BrowserBox"
+
+const { utilities, styleWith } = benefit()
+
+export default function Output({
+  utilityClasses = ["bg-blue-500", "text-white", "p-8"],
+}) {
+  const styles = utilityClasses.map((className) => {
+    const declarations = utilities[className]
+
+    const rules = Object.keys(declarations).map((property) =>
+      formatDeclaration(property, declarations[property])
+    )
+
+    return {
+      selector: css`
+        ${rules}
+      `,
+      rules,
+    }
+  })
+
+  return (
+    <div>
+      <div className="bg-white rounded shadow-xl overflow-hidden">
+        <div className="bg-gray-700 text-gray-100 items-center text-sm justify-center flex p-4">
+          <div className="font-mono">
+            {"<div class='"}
+            <div className="bg-white inline-block px-2 py-1 rounded-sm text-gray-800">
+              {utilityClasses.join(" ")}
+            </div>
+            {"'>...<div>"}
+          </div>
+        </div>
+        <div className="text-gray-800 p-4">
+          Utility classes are parsed and converted into css declarations with
+          deterministic hashes.
+        </div>
+      </div>
+      <div className="flex flex-auto justify-center text-gray-800 py-4">
+        <Icon name="arrow-down" />
+      </div>
+      <div className="bg-white rounded shadow-xl overflow-hidden">
+        <Grid minWidth="200px" className="p-4 bg-gray-700">
+          {styles.map((block) => (
+            <div
+              style={{ fontSize: "10px" }}
+              className="bg-white font-mono p-2 rounded shadow"
+            >
+              <pre>
+                <code className="block py-1">
+                  .{block.selector} {"{"}
+                </code>
+                {block.rules.map((rule) => (
+                  <code className="block py-1">
+                    {"  "}
+                    {rule}
+                  </code>
+                ))}
+                <code className="block py-1">{"}"}</code>
+              </pre>
+            </div>
+          ))}
+        </Grid>
+        <div className="text-gray-800 p-4">
+          These converted declarations are inserted into the DOM and the
+          targeted elements are given the new hash names as classes.
+        </div>
+      </div>
+      <div className="flex flex-auto justify-center text-gray-800 py-4">
+        <Icon name="arrow-down" />
+      </div>
+      <div className="bg-white rounded shadow-xl overflow-hidden">
+        <div className="bg-gray-700 text-gray-100 items-center text-sm justify-center flex p-4">
+          <div className="font-mono">
+            {"<div class='"}
+            <div className="bg-white inline-block px-2 py-1 rounded-sm text-gray-800">
+              {styles.map((declaration) => declaration.selector).join(" ")}
+            </div>
+            {"'>...<div>"}
+          </div>
+        </div>
+        <div className="text-gray-800 p-4">
+          Declarations are only inserted once so many elements can dynamically
+          use the same utility class with one insert.
+        </div>
+      </div>
+      <div>
+        <div className="flex flex-auto justify-center text-gray-800 py-4">
+          <Icon name="arrow-down" />
+        </div>
+        <div className={utilityClasses.join(" ")}>
+          Lorem ipsum dolor sit amet, pro ad iudico disputationi, stet unum sale
+          ei sea, an stet populo nominati sed. Eos unum munere voluptatum ex,
+          ludus vituperata ad per, pri diam aeque aliquip ut. Dolores persecuti
+          conceptam ei vis, duo ne clita saepe comprehensam, id mel ipsum novum.
+          Duo eu reque mollis aperiri, pro discere vivendo id, ea vel scripta
+          deleniti. Vel alii moderatius accommodare no, mel ex fastidii
+          gloriatur. Sit ea recteque contentiones.
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/docs/customization/normalize.mdx
+++ b/docs/customization/normalize.mdx
@@ -10,7 +10,7 @@ The `normalize` key is your hook to provide any base css to be applied before an
 We'll use the defaults as an example here to showcase using the defined `theme` values to help you apply any normalize styles:
 
 ```js
-;(config) => {
+function myConfig(config) {
   return {
     ...config,
     normalize: (theme) => {
@@ -31,6 +31,14 @@ We'll use the defaults as an example here to showcase using the defined `theme` 
     },
   }
 }
-``
-`
+```
+
+```js
+const { styleWith } = benefit(myConfig)
+```
+
+or
+
+```js
+<ConfigProvider config={myConfig} />
 ```

--- a/docs/customization/overview.mdx
+++ b/docs/customization/overview.mdx
@@ -5,7 +5,7 @@ parent: Customization
 rank: 1
 ---
 
-`benefit` is largely a simple library used to translate a well thought out configuration into an expressive suite of CSS utilities. You have the ability to modify the existing configuration or start entirely from scratch to create your own design system.
+`benefit` exposes the methods used to build its own default configuration. You have the option of keeping as much or as little as you want of it. Similar to how you would override a `webpack` config in other tools, just supply a function that will return your configuration.
 
 ```js
 const myConfig = (config) => {
@@ -42,10 +42,14 @@ const App = () => (
 )
 ```
 
-The configuration function will be passed in the default configuration should you need to borrow any values to compose with. The `config` object has the following shape:
+The configuration function will be passed in the default configuration should you need to borrow any values to compose with.
+
+The `config` object has the following shape:
 
 ```js
 {
+  // This prefix will prepend all utility class names
+  prefix: "",
   theme: {},
   normalize: (theme) => ({}),
   utilities: [(theme) => ({}), (theme) => ({}), ...],

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -10,27 +10,19 @@ import { Box, ConfigProvider } from "../dist/react.js"
 import Logo from "./components/Logo"
 import Alert from "./components/Alert"
 import { Playground, Link } from "docz"
+import Output from "./components/Output"
 
-### A utility system for styling web applications
+## Style web applications using generated utility classes
 
-`benefit` helps to solve the problem of elements inheriting cumbersome styles from other CSS on the page. Element-level-normalization and delightfully composable utility classes (inspired by [TailwindCSS](https://tailwindcss.com)) allow each component to render precisely as expected despite inherited CSS.
+`benefit` is a _5Kb_, utility CSS framework that's fully compatible with TailwindCSS.
 
-Another key feature of `benefit` is that _it only inlines the CSS for the utilities that you use_. So, whether you’re hardening/isolating a single React component or building a full responsive layout, only the CSS for the utilities you use get injected to the page.
+- Small runtime
+- No build step
+- Element [normalization](/customization/normalize)
+- Style isolation
+- Fully [Customizable](/customization/overview)
+- Works with [TailwindCSS](https://tailwindcss.com) class names out of box
 
-You also have the ability to customize the configuration with your own design system rules. Extend the configuration and add your own colors and CSS utilities or start entirely from scratch. It's up to you.
+And... it only inlines the CSS for the utilities that you actually use:
 
-```js
-<div className="p-4 bg-orange-300 rounded">
-  <p className="p-4 bg-white shadow rounded-sm">
-    Williamsburg stumptown iPhone, gastropub vegan banh mi
-    microdosingpost-ironic pok pok +1 bespoke dreamcatcher bushwick brunch.
-  </p>
-</div>
-```
-
-<Box className="p-4 bg-orange-300 rounded">
-  <Box is="p" className="p-4 bg-white shadow rounded-sm">
-    Williamsburg stumptown iPhone, gastropub vegan banh mi microdosing
-    post-ironic pok pok +1 bespoke dreamcatcher bushwick brunch.
-  </Box>
-</Box>
+<Output utilityClasses={["bg-blue-500", "text-white", "p-8", "rounded"]} />

--- a/docs/theme/components/Page.js
+++ b/docs/theme/components/Page.js
@@ -164,7 +164,7 @@ const pagingLink = css`
 
 function renderSubMenu(menuItems, category, iconName) {
   return (
-    <>
+    <React.Fragment>
       <Box
         className={`${menuHeading} ${partialUnderline} uppercase tracking-wide text-xs flex justify-between items-center py-2 px-4 md:px-8 text-gray-500 mt-4`}
       >
@@ -182,7 +182,7 @@ function renderSubMenu(menuItems, category, iconName) {
             {item.name}
           </Link>
         ))}
-    </>
+    </React.Fragment>
   )
 }
 

--- a/docs/theme/index.js
+++ b/docs/theme/index.js
@@ -96,10 +96,18 @@ const map = {
   // h6: components.H6,
   // ul: components.List,
   // table: components.Table,
+  ul: (props) => (
+    <Box
+      is="ul"
+      className="border-t border-b border-dashed pt-2 pb-4 list-inside"
+      {...props}
+    />
+  ),
+  li: (props) => <Box is="li" className="pt-2" {...props} />,
   a: (props) => (
     <Box
       is="a"
-      className="text-blue-500 no-decoration hover:text-blue-700"
+      className="text-blue-500 no-underline hover:text-blue-700"
       {...props}
     />
   ),

--- a/src/config/defaultConfig.js
+++ b/src/config/defaultConfig.js
@@ -4,6 +4,7 @@ import utilities from "./utilities"
 import variants from "./variants"
 
 export default {
+  prefix: "",
   theme,
   normalize,
   utilities,

--- a/src/createUtilitiesFromConfig.js
+++ b/src/createUtilitiesFromConfig.js
@@ -1,7 +1,7 @@
 import { css } from "emotion"
 import defaultConfig from "./config/defaultConfig"
 
-function formatDeclaration(property, value, isImportant) {
+export function formatDeclaration(property, value, isImportant) {
   const declaration = `${property}: ${value}`
   return `${declaration}${isImportant ? " !important" : ""};`
 }
@@ -54,6 +54,7 @@ export default function createUtilitiesFromConfig(configFn = (cfg) => cfg) {
   const config = configFn(defaultConfig)
 
   const {
+    prefix = "",
     theme = {},
     normalize = () => ({}),
     utilities = [],
@@ -69,12 +70,14 @@ export default function createUtilitiesFromConfig(configFn = (cfg) => cfg) {
     theme
   )
 
+  const prefixStr = prefix ? `${prefix}-` : ""
+
   const utilityClasses = {}
   Object.keys(generatedUtilities).forEach(
-    (key) => (utilityClasses[key] = generatedUtilities[key])
+    (key) => (utilityClasses[`${prefixStr}${key}`] = generatedUtilities[key])
   )
   Object.keys(generatedVariants).forEach(
-    (key) => (utilityClasses[key] = generatedVariants[key])
+    (key) => (utilityClasses[`${prefixStr}${key}`] = generatedVariants[key])
   )
 
   const styleWith = (classNames = "", isImportant = false) => {


### PR DESCRIPTION
If the user specifies a `prefix` key in their custom configuration, use that to prefix every utility class that is generated.

```js
const { styleWith } = benefit((config) => ({
  ...config,
  prefix: "bnft"
}))

...

<div class={styleWith("bnft-bg-blue-200")}>...</div>

```
