### PR TITLE
benefit@1.0.0" has incorrect peer dependency "emotion@~8.0.0".

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "tailwindcss": "^1.0.1"
   },
   "peerDependencies": {
-    "emotion": "~8.0.0"
+    "emotion": "~10.0.0"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
When I `yarn add benefit emotion` I get
> warning " > benefit@1.0.0" has incorrect peer dependency "emotion@~8.0.0".