### PR TITLE
IE11 compatibility

### DIFF
--- a/packages/benefit/util/initializeContainers.ts
+++ b/packages/benefit/util/initializeContainers.ts
@@ -8,7 +8,7 @@ function getMainContainer() {
 
   const benefitContainer = document.createElement("div")
   benefitContainer.setAttribute("id", "benefit-container")
-  document.body.prepend(benefitContainer)
+  document.body.insertBefore(benefitContainer, document.body.firstChild)
 
   return benefitContainer
 }


### PR DESCRIPTION
Replaces `.prepend` with `.insertBefore` since `.prepend` is not compatible with IE11 and some Edge versions.